### PR TITLE
Upgrade to openvpn v2.6.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697009197,
-        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1697076655,
-        "narHash": "sha256-NcCtVUOd0X81srZkrdP8qoA1BMsPdO2tGtlZpsGijeU=",
+        "lastModified": 1704075545,
+        "narHash": "sha256-L3zgOuVKhPjKsVLc3yTm2YJ6+BATyZBury7wnhyc8QU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aa7584f5bbf5947716ad8ec14eccc0334f0d28f0",
+        "rev": "a0df72e106322b67e9c6e591fe870380bd0da0d5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       pkgs = nixpkgs.legacyPackages.${system}.extend rust-overlay.overlays.default;
     in {
       default = self.packages.${system}.openaws-vpn-client;
-      openvpn = import ./openvpn.nix { inherit (pkgs) fetchpatch openvpn; };
+      openvpn = import ./openvpn.nix { inherit (pkgs) openvpn; };
       openaws-vpn-client = import ./openaws-vpn-client.nix {
           inherit (self.packages.${system}) openvpn;
           inherit (pkgs) makeWrapper rust-bin makeRustPlatform fetchFromGitHub lib pkg-config glib gtk3 wrapGAppsHook;

--- a/openvpn-v2.6.8-aws.patch
+++ b/openvpn-v2.6.8-aws.patch
@@ -1,0 +1,142 @@
+diff --git a/src/openvpn/buffer.h b/src/openvpn/buffer.h
+index 4cc79507..a29fae31 100644
+--- a/src/openvpn/buffer.h
++++ b/src/openvpn/buffer.h
+@@ -27,7 +27,7 @@
+ #include "basic.h"
+ #include "error.h"
+ 
+-#define BUF_SIZE_MAX 1000000
++#define BUF_SIZE_MAX (1 << 21)
+ 
+ /*
+  * Define verify_align function, otherwise
+diff --git a/src/openvpn/common.h b/src/openvpn/common.h
+index f77685c8..1a1a9eaa 100644
+--- a/src/openvpn/common.h
++++ b/src/openvpn/common.h
+@@ -66,7 +66,7 @@ typedef unsigned long ptr_type;
+  * maximum size of a single TLS message (cleartext).
+  * This parameter must be >= PUSH_BUNDLE_SIZE
+  */
+-#define TLS_CHANNEL_BUF_SIZE 2048
++#define TLS_CHANNEL_BUF_SIZE (1 << 18)
+ 
+ /* TLS control buffer minimum size
+  *
+diff --git a/src/openvpn/error.h b/src/openvpn/error.h
+index 1225b139..d13e959d 100644
+--- a/src/openvpn/error.h
++++ b/src/openvpn/error.h
+@@ -40,7 +40,10 @@
+ #if defined(ENABLE_PKCS11) || defined(ENABLE_MANAGEMENT)
+ #define ERR_BUF_SIZE 10240
+ #else
+-#define ERR_BUF_SIZE 1280
++/*
++ * Increase the error buffer size to 256 KB.
++ */
++#define ERR_BUF_SIZE (1 << 18)
+ #endif
+ 
+ struct gc_arena;
+diff --git a/src/openvpn/manage.c b/src/openvpn/manage.c
+index 739ed40f..f2109c04 100644
+--- a/src/openvpn/manage.c
++++ b/src/openvpn/manage.c
+@@ -2245,7 +2245,7 @@ man_read(struct management *man)
+     /*
+      * read command line from socket
+      */
+-    unsigned char buf[256];
++    unsigned char buf[MANAGEMENT_SOCKET_READ_BUFFER_SIZE];
+     int len = 0;
+ 
+ #ifdef TARGET_ANDROID
+@@ -2581,7 +2581,7 @@ man_connection_init(struct management *man)
+          * Allocate helper objects for command line input and
+          * command output from/to the socket.
+          */
+-        man->connection.in = command_line_new(1024);
++        man->connection.in = command_line_new(COMMAND_LINE_OPTION_BUFFER_SIZE);
+         man->connection.out = buffer_list_new();
+ 
+         /*
+diff --git a/src/openvpn/manage.h b/src/openvpn/manage.h
+index 07317a40..0f70ac62 100644
+--- a/src/openvpn/manage.h
++++ b/src/openvpn/manage.h
+@@ -58,6 +58,9 @@
+ #define MANAGEMENT_ECHO_BUFFER_SIZE           100
+ #define MANAGEMENT_STATE_BUFFER_SIZE          100
+ 
++#define COMMAND_LINE_OPTION_BUFFER_SIZE    OPTION_PARM_SIZE
++#define MANAGEMENT_SOCKET_READ_BUFFER_SIZE OPTION_PARM_SIZE
++
+ /*
+  * Management-interface-based deferred authentication
+  */
+diff --git a/src/openvpn/misc.h b/src/openvpn/misc.h
+index b000b729..af0872c7 100644
+--- a/src/openvpn/misc.h
++++ b/src/openvpn/misc.h
+@@ -65,7 +65,10 @@ struct user_pass
+ #ifdef ENABLE_PKCS11
+ #define USER_PASS_LEN 4096
+ #else
+-#define USER_PASS_LEN 128
++/*
++ * Increase the username and password length size to 128KB.
++ */
++#define USER_PASS_LEN (1 << 17)
+ #endif
+     /* Note that username and password are expected to be null-terminated */
+     char username[USER_PASS_LEN];
+diff --git a/src/openvpn/options.h b/src/openvpn/options.h
+index f5890b90..ca00c6eb 100644
+--- a/src/openvpn/options.h
++++ b/src/openvpn/options.h
+@@ -54,8 +54,8 @@
+ /*
+  * Max size of options line and parameter.
+  */
+-#define OPTION_PARM_SIZE 256
+-#define OPTION_LINE_SIZE 256
++#define OPTION_PARM_SIZE USER_PASS_LEN
++#define OPTION_LINE_SIZE OPTION_PARM_SIZE
+ 
+ extern const char title_string[];
+ 
+diff --git a/src/openvpn/ssl.c b/src/openvpn/ssl.c
+index 12bc85f9..b202e4a7 100644
+--- a/src/openvpn/ssl.c
++++ b/src/openvpn/ssl.c
+@@ -1929,7 +1929,7 @@ tls_session_soft_reset(struct tls_multi *tls_multi)
+ static bool
+ write_empty_string(struct buffer *buf)
+ {
+-    if (!buf_write_u16(buf, 0))
++    if (!buf_write_u32(buf, 0))
+     {
+         return false;
+     }
+@@ -1944,7 +1944,7 @@ write_string(struct buffer *buf, const char *str, const int maxlen)
+     {
+         return false;
+     }
+-    if (!buf_write_u16(buf, len))
++    if (!buf_write_u32(buf, len))
+     {
+         return false;
+     }
+@@ -2284,6 +2284,10 @@ key_method_2_write(struct buffer *buf, struct tls_multi *multi, struct tls_sessi
+         p2p_mode_ncp(multi, session);
+     }
+ 
++    // Write key length in the first 4 octets of the buffer.
++    uint32_t length = BLEN(buf);
++    memcpy(buf->data, &length, sizeof(length));
++
+     return true;
+ 
+ error:

--- a/openvpn.nix
+++ b/openvpn.nix
@@ -1,12 +1,4 @@
-{ openvpn
-, fetchpatch
-}:
-
-openvpn.overrideAttrs (oldAttrs: rec {
-  patches = [
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/samm-git/aws-vpn-client/master/openvpn-v2.5.1-aws.patch";
-      hash = "sha256-9ijhANqqWXVPa00RBCRACtMIsjiBqYVa91V62L4mNas=";
-    })
-  ];
+{openvpn}:
+openvpn.overrideAttrs (oldAttrs: {
+  patches = [./openvpn-v2.6.8-aws.patch];
 })


### PR DESCRIPTION
I re-rolled the patch file -- adding some parens around #define values to avoid potential precedence trouble -- and simplified the nix a little bit.

I'm currently using this script to run the app:

```bash
#!/usr/bin/env bash
OPENVPN_FILE=$(which openvpn) openaws-vpn-client
```

because otherwise it can't find the openvpn binary.

Here's how I added it to my nixos system flake:

```nix
          ({lib, ...}: {
            # Beware: https://github.com/NixOS/nixpkgs/issues/191910
            nixpkgs.config.allowUnfree = true;
            nixpkgs.overlays = [
              (_: _: {
                openvpn = inputs.openaws-vpn-client.outputs.packages.${system}.openvpn;
                openaws-vpn-client = inputs.openaws-vpn-client.outputs.packages.${system}.openaws-vpn-client;
              })
            ];
          })
```

[in context](https://github.com/adamdicarlo/nixos-config/blob/a12fd89a9563905e8282b434b4b03b3a587cfe2e/flake.nix#L160-L169)

and added both openvpn and openaws-vpn-client to my `environment.systemPackages`:

https://github.com/adamdicarlo/nixos-config/blob/a12fd89a9563905e8282b434b4b03b3a587cfe2e/machines/tiv/default.nix#L135-L136
